### PR TITLE
fix compilation of paper

### DIFF
--- a/create_dev_env.R
+++ b/create_dev_env.R
@@ -26,7 +26,7 @@ rix(
     "foreach",
     "ggokabeito"
   ),
-  system_pkgs = c("quarto", "git", "pandoc"),
+  system_pkgs = c("ungoogled-chromium", "quarto", "git", "pandoc"),
   git_pkgs = list(
     list(
       package_name = "webgazer",


### PR DESCRIPTION
As explained here, fix the compilation of the paper: https://github.com/ropensci/rix/issues/381#issuecomment-2586553192

`gt::gtsave()` requires an installation of Chrome at runtime to work, so it builds successfully, but does not work successfully. This issue can remain undetected if you try to build the paper in an environment where Chrome is present. This fix will ensure that the paper successfully compiles even on a system without Chrome.