### PR TITLE
fix build on CI

### DIFF
--- a/_manuscript/L2_VWP_webcam_ET.qmd
+++ b/_manuscript/L2_VWP_webcam_ET.qmd
@@ -144,6 +144,7 @@ execute:
 
 library(knitr)
 opts_chunk$set(fig.align='center', size="small")
+options(chromote.timeout = 60)
 ```
 
 Eye-tracking technology, which has a history spanning over a century, has seen remarkable advancements. In the early days, eye-tracking sometimes required the use of contact lenses fitted with search coils, often requiring anesthesia, or the attachment of suction cups to the sclera of the eyes [@pluzyczka2018]. These methods were not only cumbersome for the researcher, but also uncomfortable and invasive for participants. Over time, such approaches have been replaced by non-invasive, lightweight, and user-friendly systems. Today, modern eye-tracking technology is widely accessible in laboratories worldwide, enabling researchers to tackle critical questions about cognitive processes . This evolution has had a profound impact on fields such as psycholinguistics and bilingualism opening up new possibilities for understanding how language is processed in real time [@godfroid].


### PR DESCRIPTION
I saw that quarto fails to render sometimes on CI: this is due to {chromote} (a dependency of {gt}) needing more time than the default 10 seconds startup to start a server. 

Setting `options(chromote.timeout = 60)` seems to work more reliably.

See https://github.com/rstudio/chromote/issues/114#issuecomment-1675406196