### PR TITLE
Remove Nix cache

### DIFF
--- a/.github/workflows/render_paper.yml
+++ b/.github/workflows/render_paper.yml
@@ -44,10 +44,6 @@ jobs:
         log-directives: nix_installer=trace
         backtrace: full
 
-    - name: Nix cache
-      if: env.changed == 'true'
-      uses: DeterminateSystems/magic-nix-cache-action@main
-
     - name: Generate default.nix
       if: env.changed == 'true'
       run: nix-shell -p R rPackages.rix --run "R -e 'source(\"create_dev_env.R\")'"


### PR DESCRIPTION
Unfortunately the Determinaty Systems Nix cache action will stop working on February 1st, as Github will deprecate and decommission their current API for caches. See: https://determinate.systems/posts/magic-nix-cache-free-tier-eol/