### PR TITLE
Use rstats-on-nix cache

### DIFF
--- a/.github/workflows/render_paper.yml
+++ b/.github/workflows/render_paper.yml
@@ -48,6 +48,12 @@ jobs:
       if: env.changed == 'true'
       uses: DeterminateSystems/magic-nix-cache-action@main
 
+    - name: Use rstats-on-nix cache
+      if: env.changed == 'true'
+      uses: cachix/cachix-action@v15
+      with:
+        name: rstats-on-nix
+
     - name: Generate default.nix
       if: env.changed == 'true'
       run: nix-shell -p R rPackages.rix --run "R -e 'source(\"create_dev_env.R\")'"


### PR DESCRIPTION
I realize I forgot to add the action to use our rstats-on-nix cache which contains many pre-compiled R packages. This should speed up the building of the environment.